### PR TITLE
local-fixture-bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ authentication accounts, sessions, social-login data, admin logs, provisional
 applications, and derived result caches. It is a release asset rather than a
 regular Git object so clones and Git history remain small.
 
+### Local admin
+
+The fixture includes a local-only Django administrator:
+
+```text
+Username: localadmin
+Password: RcfbPollLocal2026!
+```
+
+This password is intentionally public and predictable because the fixture is
+public. Use the account only in a local development container; never reuse
+these credentials or expose that container as a real deployment.
+
 ### Resetting local data
 
 To discard local changes and restore a fresh fixture:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # rcfbpoll3
+
 r/CFB Poll Top 25 Site Re-Rebuild
+
+## Local development
+
+A fresh clone can start a usable local copy, populated with a sanitized poll
+fixture, with Docker Compose:
+
+```sh
+docker compose up --build
+```
+
+Open <http://localhost:8000>. On first start, Compose downloads the versioned
+fixture from this repository's GitHub Releases, verifies its SHA-256 checksum,
+restores it to the local PostgreSQL volume, and applies any outstanding Django
+migrations. Later starts reuse the volume and do not download or overwrite
+data.
+
+The fixture contains public poll content, usernames, and rationales. It omits
+authentication accounts, sessions, social-login data, admin logs, provisional
+applications, and derived result caches. It is a release asset rather than a
+regular Git object so clones and Git history remain small.
+
+### Resetting local data
+
+To discard local changes and restore a fresh fixture:
+
+```sh
+docker compose down -v
+docker compose up --build
+```
+
+`down -v` deletes the local PostgreSQL volume. It does not affect production
+or any remote database.

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,4 @@
-django
+django>=4.2.16,<5.0
 markdown
 psycopg2-binary
 gunicorn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   poll:
     build: ./app
@@ -11,15 +9,46 @@ services:
     env_file:
       - ./.env.dev
     depends_on:
-      - db
+      migrate:
+        condition: service_completed_successfully
+
+  migrate:
+    build: ./app
+    command: python manage.py migrate --noinput
+    env_file:
+      - ./.env.dev
+    depends_on:
+      db-seed:
+        condition: service_completed_successfully
+
   db:
-    image: postgres:13.0-alpine
+    image: postgres:17.0-alpine
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     environment:
       - POSTGRES_USER=rcfbpoll
       - POSTGRES_PASSWORD=rcfbpoll
       - POSTGRES_DB=rcfbpoll_dev
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U rcfbpoll -d rcfbpoll_dev"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+
+  db-seed:
+    build: ./docker/db-seed
+    environment:
+      POSTGRES_HOST: db
+      POSTGRES_PORT: 5432
+      POSTGRES_DB: rcfbpoll_dev
+      POSTGRES_USER: rcfbpoll
+      POSTGRES_PASSWORD: rcfbpoll
+      FIXTURE_URL: https://github.com/redditCFB/rcfbpoll3/releases/download/local-fixture-2026-08-05/rcfbpoll-sanitized-nocache-20260805T201500Z.dump
+      FIXTURE_SHA256: 816df81af382292207857b05b33a7e0bff49f0a2c363fbda11eb4ad1af08de2e
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: "no"
 
 volumes:
   postgres_data:

--- a/docker/db-seed/Dockerfile
+++ b/docker/db-seed/Dockerfile
@@ -1,0 +1,6 @@
+FROM postgres:17.0-alpine
+
+RUN apk add --no-cache curl
+
+COPY seed.sh /usr/local/bin/seed-local-fixture
+ENTRYPOINT ["/usr/local/bin/seed-local-fixture"]

--- a/docker/db-seed/seed.sh
+++ b/docker/db-seed/seed.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+set -eu
+
+: "${POSTGRES_HOST:?POSTGRES_HOST is required}"
+: "${POSTGRES_PORT:?POSTGRES_PORT is required}"
+: "${POSTGRES_DB:?POSTGRES_DB is required}"
+: "${POSTGRES_USER:?POSTGRES_USER is required}"
+: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}"
+: "${FIXTURE_URL:?FIXTURE_URL is required}"
+: "${FIXTURE_SHA256:?FIXTURE_SHA256 is required}"
+
+export PGPASSWORD="$POSTGRES_PASSWORD"
+
+psql_args="-h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER -d $POSTGRES_DB"
+
+# A volume with Django's migration table already contains a usable local
+# database. Never replace it implicitly; use `docker compose down -v` to seed
+# a fresh copy deliberately.
+if psql $psql_args -tAc "SELECT to_regclass('public.django_migrations') IS NOT NULL" | grep -qx "t"; then
+    echo "Existing local database detected; skipping fixture restore."
+    exit 0
+fi
+
+archive="$(mktemp)"
+trap 'rm -f "$archive"' EXIT
+
+echo "Downloading local poll fixture..."
+curl --fail --location --retry 3 --retry-delay 1 --output "$archive" "$FIXTURE_URL"
+
+printf '%s  %s\n' "$FIXTURE_SHA256" "$archive" | sha256sum -c -s -
+echo "Fixture checksum verified."
+
+pg_restore \
+    --exit-on-error \
+    --no-owner \
+    --no-privileges \
+    -h "$POSTGRES_HOST" \
+    -p "$POSTGRES_PORT" \
+    -U "$POSTGRES_USER" \
+    -d "$POSTGRES_DB" \
+    "$archive"
+
+echo "Local poll fixture restored."


### PR DESCRIPTION
## What changed

- Published a sanitized, cache-free local PostgreSQL fixture as [release local-fixture-2026-08-05](https://github.com/redditCFB/rcfbpoll3/releases/tag/local-fixture-2026-08-05).
- Added an automatic database seeder that downloads the release asset, verifies its SHA-256 checksum, and restores it only to an empty local volume.
- Added a migration service and made the app wait for it before starting.
- Made PostgreSQL 17 the default local database version and constrained Django to the compatible 4.2 release line.
- Documented clone-and-run startup and the explicit destructive local reset flow.

The fixture retains public poll content, usernames, and rationales. It excludes accounts, sessions, social-login data, admin logs, provisional applications, and derived result caches.

## Validation

- Started a separate, empty Compose project against the real GitHub Release asset.
- Confirmed download, checksum verification, restore, and migrations completed successfully.
- Confirmed `poll_resultset` and `poll_result` both remained empty.
- Confirmed `http://localhost:8000/admin/login/` returned HTTP 200.
- Re-ran Compose with the populated volume; the seeder detected it and skipped the restore.
