### PR TITLE
fix-provisional-reapplication

### DIFF
--- a/app/poll/tests.py
+++ b/app/poll/tests.py
@@ -1,3 +1,59 @@
-from django.test import TestCase
+from datetime import timedelta
 
-# Create your tests here.
+from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test import TransactionTestCase
+from django.utils import timezone
+
+from poll.models import ProvisionalUserApplication, Team, User, UserRole
+
+
+class ProvisionalApplicationTests(TransactionTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        with connection.schema_editor() as schema_editor:
+            for model in (Team, User, UserRole, ProvisionalUserApplication):
+                schema_editor.create_model(model)
+
+    @classmethod
+    def tearDownClass(cls):
+        with connection.schema_editor() as schema_editor:
+            for model in (ProvisionalUserApplication, UserRole, User, Team):
+                schema_editor.delete_model(model)
+        super().tearDownClass()
+
+    def setUp(self):
+        self.auth_user = get_user_model().objects.create_user(
+            username='former_provisional',
+            password='test-password',
+        )
+        self.poll_user = User.objects.create(username=self.auth_user.username)
+        self.client.force_login(self.auth_user)
+
+    def test_revoked_provisional_voter_can_reapply(self):
+        ProvisionalUserApplication.objects.create(
+            user=self.poll_user,
+            submission_date=timezone.now() - timedelta(days=1),
+            status=ProvisionalUserApplication.Status.ACCEPTED,
+        )
+        UserRole.objects.create(
+            user=self.poll_user,
+            role=UserRole.Role.PROVISIONAL,
+            start_date=timezone.now() - timedelta(days=30),
+            end_date=timezone.now() - timedelta(days=1),
+        )
+
+        response = self.client.get('/my_ballots/')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context['app'])
+        self.assertContains(response, 'Apply')
+
+        response = self.client.get('/apply_for_provisional/')
+
+        self.assertRedirects(response, '/my_ballots/')
+        latest_application = ProvisionalUserApplication.objects.latest('submission_date')
+        self.assertEqual(latest_application.user, self.poll_user)
+        self.assertEqual(latest_application.status, ProvisionalUserApplication.Status.OPEN)
+        self.assertEqual(ProvisionalUserApplication.objects.count(), 2)

--- a/app/poll/views.py
+++ b/app/poll/views.py
@@ -335,9 +335,12 @@ def my_ballots(request):
 
     if not this_user.is_voter and not this_user.is_provisional_voter:
         app = ProvisionalUserApplication.objects.filter(user=this_user).order_by('-submission_date').first()
-        if (
-            app and app.status == ProvisionalUserApplication.Status.REJECTED
-            and (timezone.now() - app.submission_date).days > 180
+        if app and (
+            app.status == ProvisionalUserApplication.Status.ACCEPTED
+            or (
+                app.status == ProvisionalUserApplication.Status.REJECTED
+                and (timezone.now() - app.submission_date).days > 180
+            )
         ):
             app = None
         return render(request, 'not_a_voter.html', {
@@ -378,8 +381,11 @@ def apply_for_provisional(request):
 
     app = ProvisionalUserApplication.objects.filter(user=this_user).order_by('-submission_date').first()
     if app and (
-            app.status != ProvisionalUserApplication.Status.REJECTED
-            or (timezone.now() - app.submission_date).days <= 180
+        app.status == ProvisionalUserApplication.Status.OPEN
+        or (
+            app.status == ProvisionalUserApplication.Status.REJECTED
+            and (timezone.now() - app.submission_date).days <= 180
+        )
     ):
         return redirect('/my_ballots/')
 


### PR DESCRIPTION
Fixes #28.

## What changed

- Treat an accepted provisional application as historical once the voter no longer has an active provisional role.
- Allow that former provisional voter to submit a new application.
- Show the application CTA instead of the stale accepted-application status.

## Validation

- Added a regression test for a former provisional voter whose role was end-dated.
- Ran `python manage.py test poll` in a disposable PostgreSQL 17 Compose project: 1 test passed.

The test creates its four required legacy poll tables because the repository has no usable Django migrations for the poll app in a fresh test database.
