### PR TITLE
Fix short conference ballot cards

### DIFF
--- a/app/poll/static/css/poll.css
+++ b/app/poll/static/css/poll.css
@@ -86,3 +86,7 @@ body {
     width: 60px;
 	horiz-align: center;
 }
+
+#conference-teams {
+    min-width: 0;
+}

--- a/app/poll/templates/edit_ballot.html
+++ b/app/poll/templates/edit_ballot.html
@@ -33,13 +33,13 @@
         <div class="row flex-lg-row py-3 justify-content-center">
             <p>Current Teams Selected: <span id="current-teams">0</span>/25</p>
             <div id="alertPlaceholder"></div>
-			<div class="col-xl-12 col-xxl-6 d-flex align-items-start">
+			<div class="col-12 col-xl-12 col-xxl-6 d-flex align-items-start">
                 <div class="nav flex-column nav-pills me-3" id="conference-tabs" role="tablist" aria-orientation="vertical">
                     {% for conference in team_groups %}
                         <button class="nav-link" id="{{ conference }}-tab" data-bs-toggle="pill" data-bs-target="#{{ conference }}" type="button" role="tab" aria-controls="{{ conference }}" aria-selected="false">{{ conference }}</button>
                     {% endfor %}
                 </div>
-                <div class="tab-content" id="conference-teams">
+                <div class="tab-content flex-grow-1" id="conference-teams">
                     {% for conference, teams in team_groups.items %}
                         <div class="tab-pane fade" id="{{ conference }}" role="tabpanel" aria-labelledby="{{ conference }}-tab" tabindex="0">
                             <div class="row justify-content-center">


### PR DESCRIPTION
## What changed

- Give the team-selector panel a stable width at every breakpoint.
- Allow the conference tab content to grow into the remaining width beside the conference navigation.
- Permit the tab content to shrink within that flex row, so the existing two-column mobile cards use the available space instead of collapsing.

## Why

When a conference contains only a few teams, the team-selector panel can shrink to the intrinsic width of those cards. That leaves Bootstrap's percentage-width columns with almost no usable width. It is most conspicuous on phones, but can occur at any viewport size.

PR #33 explored the same symptom. This PR keeps the fix focused on the layout constraint that causes the collapse and does not add its card restyling or resize JavaScript.

## Validation

- Started an isolated empty-volume Compose stack from this branch.
- Ran `python manage.py check` successfully; only the existing django-allauth deprecation warnings remain.
- Confirmed `/admin/login/` returns HTTP 200.
- Browser visual automation was unavailable because the in-app browser could not verify its localhost security policy.