### PR TITLE
Pin Django Debug Toolbar below 6

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -2,7 +2,7 @@ django>=4.2.16,<5.0
 markdown
 psycopg2-binary
 gunicorn
-django-debug-toolbar
+django-debug-toolbar>=5.2,<6.0
 pytz
 django-allauth
 requests


### PR DESCRIPTION
## What changed

Pins `django-debug-toolbar` to the supported 5.x release line.

## Why

The project caps Django below 5.0, but the unbounded dependency recently resolved to Debug Toolbar 7.0, which requires Django 5.2 or later. That made Docker image builds fail during dependency installation.

## Impact

Local and deployment image builds continue using Django 4.2 and now resolve Debug Toolbar 5.2.0 instead of an incompatible release.

## Validation

Ran a Dockerized pip resolver check for Django 4.2, django-allauth, and the new toolbar constraint. It resolved successfully to Django 4.2.30 and django-debug-toolbar 5.2.0.
