### PR TITLE
Add copy-rationale action for new ballots

### DIFF
--- a/app/poll/static/javascript/ballot.js
+++ b/app/poll/static/javascript/ballot.js
@@ -38,6 +38,9 @@ $(function() {
     $("#validate-button").click(function() {
         saveBallot('validate');
     });
+    $("#copy-rationale-button").click(function() {
+        $("#overall-rationale").val($(this).data("rationale"));
+    });
 });
 
 function addTeamToBallot(team_handle) {

--- a/app/poll/templates/edit_ballot.html
+++ b/app/poll/templates/edit_ballot.html
@@ -17,6 +17,9 @@
             <div class="form-floating my-3">
                 <textarea class="form-control" placeholder="" id="overall-rationale" name="overall-rationale">{{ ballot.overall_rationale }}</textarea>
                 <label for="overall-rationale">Overall Rationale/Methodology</label>
+                {% if previous_rationale %}
+                    <button type="button" class="btn btn-secondary mt-2" id="copy-rationale-button" data-rationale="{{ previous_rationale }}">Copy rationale from last submitted ballot</button>
+                {% endif %}
             </div>
             <label for="page"></label>
             <select class="form-select d-none" id="page" name="page">

--- a/app/poll/test_copy_rationale.py
+++ b/app/poll/test_copy_rationale.py
@@ -1,0 +1,94 @@
+from datetime import timedelta
+from types import SimpleNamespace
+
+from django.db import connection
+from django.test import RequestFactory, TransactionTestCase
+from django.utils import timezone
+
+from poll import views
+from poll.models import Ballot, BallotEntry, Poll, Team, User, UserRole
+
+
+class CopyPreviousRationaleTests(TransactionTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        with connection.schema_editor() as schema_editor:
+            for model in (Team, User, Poll, Ballot, BallotEntry):
+                schema_editor.create_model(model)
+
+    @classmethod
+    def tearDownClass(cls):
+        with connection.schema_editor() as schema_editor:
+            for model in (BallotEntry, Ballot, Poll, User, Team):
+                schema_editor.delete_model(model)
+        super().tearDownClass()
+
+    def setUp(self):
+        now = timezone.now()
+        self.poll = Poll.objects.create(
+            year=2026,
+            week="Preseason",
+            open_date=now - timedelta(days=1),
+            close_date=now + timedelta(days=1),
+            publish_date=now - timedelta(days=7),
+            ap_date=now - timedelta(days=7),
+        )
+        self.user = User.objects.create(username="rationale-user")
+        Team.objects.create(
+            handle="ecu",
+            name="ECU Pirates",
+            conference="American",
+            division="FBS",
+            use_for_ballot=True,
+            short_name="ECU",
+        )
+        self.ballot = Ballot.objects.create(
+            user=self.user,
+            poll=self.poll,
+            user_type=UserRole.Role.VOTER,
+        )
+        self.request_factory = RequestFactory()
+
+    def render_ballot(self):
+        request = self.request_factory.get(f"/ballot/edit/{self.ballot.id}/")
+        request.user = SimpleNamespace(username=self.user.username)
+        return views.edit_ballot(request, self.ballot.id)
+
+    def test_hides_copy_button_without_a_previous_submission(self):
+        response = self.render_ballot()
+
+        self.assertNotContains(response, "copy-rationale-button")
+
+    def test_shows_copy_button_with_rationale_from_previous_submission(self):
+        Ballot.objects.create(
+            user=self.user,
+            poll=self.poll,
+            submission_date=timezone.now() - timedelta(days=1),
+            user_type=UserRole.Role.VOTER,
+            overall_rationale="Ranked teams by strength of schedule.",
+        )
+
+        response = self.render_ballot()
+
+        self.assertContains(response, "copy-rationale-button")
+        self.assertContains(response, 'data-rationale="Ranked teams by strength of schedule."')
+
+    def test_hides_copy_button_when_latest_submission_has_no_rationale(self):
+        Ballot.objects.create(
+            user=self.user,
+            poll=self.poll,
+            submission_date=timezone.now() - timedelta(days=2),
+            user_type=UserRole.Role.VOTER,
+            overall_rationale="Older rationale",
+        )
+        Ballot.objects.create(
+            user=self.user,
+            poll=self.poll,
+            submission_date=timezone.now() - timedelta(days=1),
+            user_type=UserRole.Role.VOTER,
+        )
+
+        response = self.render_ballot()
+
+        self.assertNotContains(response, "copy-rationale-button")

--- a/app/poll/views.py
+++ b/app/poll/views.py
@@ -552,6 +552,14 @@ def edit_ballot(request, ballot_id):
         conferences = list(
             teams.filter(division='FBS').values_list('conference', flat=True).distinct().order_by('conference')
         )
+        last_submitted_ballot = Ballot.objects.filter(
+            user=ballot.user, submission_date__isnull=False
+        ).exclude(pk=ballot.pk).order_by('-submission_date').first()
+        previous_rationale = (
+            last_submitted_ballot.overall_rationale
+            if last_submitted_ballot and last_submitted_ballot.overall_rationale
+            else None
+        )
 
         team_groups = {}
         for conference in conferences:
@@ -575,7 +583,8 @@ def edit_ballot(request, ballot_id):
             'entries': entries,
             'teams': team_dict,
             'team_groups': team_groups,
-            'ranks': range(1, 26)
+            'ranks': range(1, 26),
+            'previous_rationale': previous_rationale
         })
 
 


### PR DESCRIPTION
Closes #20.\n\nAdds a conditional button to the ballot editor that copies the rationale from the user’s most recent submitted ballot. The option is hidden when there is no prior submission or when the latest submission has no rationale.\n\nValidation: 14 poll tests passed.