### PR TITLE
Preserve line breaks in rationale displays

### DIFF
--- a/app/poll/templates/ballot_view.html
+++ b/app/poll/templates/ballot_view.html
@@ -23,7 +23,7 @@
         {% endif %}
         {% if not ballot.overall_rationale == '' %}
             <p>
-                <strong>Overall Rationale:</strong> {{ ballot.overall_rationale }}
+                <strong>Overall Rationale:</strong> {{ ballot.overall_rationale|linebreaksbr }}
             </p>
         {% endif %}
         {% if ballot.poll.is_published or user.is_staff %}
@@ -53,7 +53,7 @@
                                         {{ entry.team.name }}
                                         </a>
                                     </td>
-                                    <td>{{ entry.rationale }}</td>
+                                    <td>{{ entry.rationale|linebreaksbr }}</td>
                                 </tr>
                             {% endfor %}
                         </table>

--- a/app/poll/templates/team_view.html
+++ b/app/poll/templates/team_view.html
@@ -60,7 +60,7 @@
                                 </a>
                             </td>
                             <td class="text-center">{{ entry.rank }}</td>
-                            <td>{{ entry.rationale }}</td>
+                            <td>{{ entry.rationale|linebreaksbr }}</td>
                         </tr>
                     {% endif %}
                 {% endfor %}
@@ -87,7 +87,7 @@
                                 </a>
                             </td>
                             <td class="text-center">{{ entry.rank }}</td>
-                            <td>{{ entry.rationale }}</td>
+                            <td>{{ entry.rationale|linebreaksbr }}</td>
                         </tr>
                     {% endif %}
                 {% endfor %}

--- a/app/poll/templates/validate_ballot.html
+++ b/app/poll/templates/validate_ballot.html
@@ -8,7 +8,7 @@
                     <strong>Ballot Type:</strong> {{ ballot.get_poll_type_display }}
                 </p>
                 <p>
-                    <strong>Overall Rationale:</strong> {{ ballot.overall_rationale }}
+                    <strong>Overall Rationale:</strong> {{ ballot.overall_rationale|linebreaksbr }}
                 </p>
                 <table class="table table-sm table-striped">
                     <tr>
@@ -24,7 +24,7 @@
                                 {{ entry.team.short_name }}
                                 </a>
                             </td>
-                            <td>{{ entry.rationale }}</td>
+                            <td>{{ entry.rationale|linebreaksbr }}</td>
                         </tr>
                     {% endfor %}
                 </table>


### PR DESCRIPTION
Closes #15.\n\nRationale and per-team reasons were rendered as plain text, so HTML collapsed user-entered newlines. Apply Django’s escaping linebreaksbr filter in the ballot, validation, and team views so multiline methodology and reasons remain readable.\n\nValidation: 11 poll tests passed.