### PR TITLE
Add People’s Poll link to post generator

### DIFF
--- a/app/poll/templates/poll_post.html
+++ b/app/poll/templates/poll_post.html
@@ -40,6 +40,7 @@
         <br><br>
         * [Detailed Results]({{ links.results }})<br>
         * [Results w/Provisional Voters]({{ links.provisional }})<br>
+        * [THE PEOPLE'S POLL]({{ links.provisional }})<br>
         * [Voter List]({{ links.voters }})<br>
         * [Ballots]({{ links.ballots }})<br>
         * [Analysis]({{ links.analysis }})

--- a/app/poll/templates/poll_post.html
+++ b/app/poll/templates/poll_post.html
@@ -40,7 +40,7 @@
         <br><br>
         * [Detailed Results]({{ links.results }})<br>
         * [Results w/Provisional Voters]({{ links.provisional }})<br>
-        * [THE PEOPLE'S POLL]({{ links.provisional }})<br>
+        * [THE PEOPLE'S POLL]({{ links.peoples_poll }})<br>
         * [Voter List]({{ links.voters }})<br>
         * [Ballots]({{ links.ballots }})<br>
         * [Analysis]({{ links.analysis }})

--- a/app/poll/test_poll_post.py
+++ b/app/poll/test_poll_post.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+
+from django.template.loader import get_template
+from django.test import RequestFactory, SimpleTestCase
+
+
+class PollPostTemplateTests(SimpleTestCase):
+    def test_includes_the_peoples_poll_link(self):
+        request = RequestFactory().get('/poll_post/')
+        request.user = SimpleNamespace(is_anonymous=False, is_staff=False, username='test-user')
+        top25 = [
+            SimpleNamespace(
+                rank_diff=0,
+                rank=rank,
+                rank_diff_str='--',
+                team=SimpleNamespace(handle=f'team-{rank}', name=f'Team {rank}', short_name=f'Team {rank}'),
+                first_place_votes=0,
+                points=100,
+            )
+            for rank in range(1, 6)
+        ]
+        rendered = get_template('poll_post.html').render({
+            'poll': '2025 Week 12',
+            'top25': top25,
+            'next_ten': [],
+            'dropped': [],
+            'links': {
+                'results': 'https://poll.example/results',
+                'provisional': 'https://poll.example/peoples-poll',
+                'voters': 'https://poll.example/voters',
+                'ballots': 'https://poll.example/ballots',
+                'analysis': 'https://poll.example/analysis',
+                'about': 'https://poll.example/about',
+                'faq': 'https://poll.example/faq',
+                'contribute': 'https://poll.example/contribute',
+                'hall': 'https://poll.example/hall',
+            },
+        }, request)
+
+        self.assertIn('* [THE PEOPLE\'S POLL](https://poll.example/peoples-poll)<br>', rendered)

--- a/app/poll/test_poll_post.py
+++ b/app/poll/test_poll_post.py
@@ -27,6 +27,7 @@ class PollPostTemplateTests(SimpleTestCase):
             'links': {
                 'results': 'https://poll.example/results',
                 'provisional': 'https://poll.example/peoples-poll',
+                'peoples_poll': 'https://poll.example/peoples-poll?provisional=on',
                 'voters': 'https://poll.example/voters',
                 'ballots': 'https://poll.example/ballots',
                 'analysis': 'https://poll.example/analysis',
@@ -37,4 +38,4 @@ class PollPostTemplateTests(SimpleTestCase):
             },
         }, request)
 
-        self.assertIn('* [THE PEOPLE\'S POLL](https://poll.example/peoples-poll)<br>', rendered)
+        self.assertIn("* [THE PEOPLE'S POLL](https://poll.example/peoples-poll?provisional=on)<br>", rendered)

--- a/app/poll/views.py
+++ b/app/poll/views.py
@@ -394,6 +394,9 @@ def poll_post(request):
         'provisional': request.build_absolute_uri(
             '/poll/view/%d/?main=on&provisional=on&human=on&computer=on&hybrid=on&before_ap=on&after_ap=on' % poll.id
         ),
+        'peoples_poll': request.build_absolute_uri(
+            '/poll/view/%d/?provisional=on&human=on&computer=on&hybrid=on&before_ap=on&after_ap=on' % poll.id
+        ),
         'voters': request.build_absolute_uri('/poll/voters/%d/' % poll.id),
         'ballots': request.build_absolute_uri('/poll/ballots/%d/' % poll.id),
         'analysis': request.build_absolute_uri('/poll/analysis/%d/' % poll.id),


### PR DESCRIPTION
Adds the PEOPLE’S POLL bullet to generated Reddit posts, matching the existing provisional-inclusive results destination shown in the reference post.\n\nValidation: 13 poll tests passed.