### PR TITLE
Link hosted summary image in post generator

### DIFF
--- a/app/poll/templates/poll_post.html
+++ b/app/poll/templates/poll_post.html
@@ -16,8 +16,6 @@
         </h4>
         Here are the results for the {{ poll }} /r/CFB Poll:<br>
         <br>
-        **POLL SUMMARY:** [View the automated poll summary image]({{ links.summary_image }})<br>
-        <br>
         |Rank|Change|Team (#1 Votes)|Points|<br>
         |:--:|:--:|:--|:--:|<br>
         {% for rank in top25 %}
@@ -39,6 +37,7 @@
         <br><br>
         **POLL SITE**: https://poll.redditcfb.com/
         <br><br>
+        * [Poll Summary Image]({{ links.summary_image }})<br>
         * [Detailed Results]({{ links.results }})<br>
         * [Results w/Provisional Voters]({{ links.provisional }})<br>
         * [THE PEOPLE'S POLL]({{ links.peoples_poll }})<br>

--- a/app/poll/templates/poll_post.html
+++ b/app/poll/templates/poll_post.html
@@ -14,15 +14,9 @@
             #4 {{ top25.3.team.short_name }}
             #5 {{ top25.4.team.short_name }}
         </h4>
-        <div class="my-3">
-            <h5>Post summary image</h5>
-            <img src="{{ links.summary_image }}" class="img-fluid border rounded" alt="Automated poll summary image">
-            <br>
-            <a class="btn btn-primary mt-2" href="{{ links.summary_image }}" download>Download summary image</a>
-            <a class="btn btn-secondary mt-2" href="{{ links.summary_image_refresh }}">Regenerate image</a>
-        </div>
-        <br>
         Here are the results for the {{ poll }} /r/CFB Poll:<br>
+        <br>
+        **POLL SUMMARY:** [View the automated poll summary image]({{ links.summary_image }})<br>
         <br>
         |Rank|Change|Team (#1 Votes)|Points|<br>
         |:--:|:--:|:--|:--:|<br>

--- a/app/poll/test_poll_post.py
+++ b/app/poll/test_poll_post.py
@@ -27,10 +27,9 @@ class PollPostTemplateTests(SimpleTestCase):
             'links': {'summary_image': 'https://poll.example/summary/12.png'},
         }, request)
 
-        self.assertIn(
-            '**POLL SUMMARY:** [View the automated poll summary image](https://poll.example/summary/12.png)<br>',
-            rendered,
-        )
+        summary_link = '* [Poll Summary Image](https://poll.example/summary/12.png)<br>'
+        self.assertIn(summary_link, rendered)
+        self.assertLess(rendered.index(summary_link), rendered.index('* [Detailed Results]'))
         self.assertNotIn('<img src="https://poll.example/summary/12.png"', rendered)
 
     def test_includes_the_peoples_poll_link(self):

--- a/app/poll/test_poll_post.py
+++ b/app/poll/test_poll_post.py
@@ -5,6 +5,34 @@ from django.test import RequestFactory, SimpleTestCase
 
 
 class PollPostTemplateTests(SimpleTestCase):
+    def test_includes_summary_image_link_without_embedding_image(self):
+        request = RequestFactory().get('/poll_post/')
+        request.user = SimpleNamespace(is_anonymous=False, is_staff=False, username='test-user')
+        top25 = [
+            SimpleNamespace(
+                rank_diff=0,
+                rank=rank,
+                rank_diff_str='--',
+                team=SimpleNamespace(handle=f'team-{rank}', name=f'Team {rank}', short_name=f'Team {rank}'),
+                first_place_votes=0,
+                points=100,
+            )
+            for rank in range(1, 6)
+        ]
+        rendered = get_template('poll_post.html').render({
+            'poll': '2025 Week 12',
+            'top25': top25,
+            'next_ten': [],
+            'dropped': [],
+            'links': {'summary_image': 'https://poll.example/summary/12.png'},
+        }, request)
+
+        self.assertIn(
+            '**POLL SUMMARY:** [View the automated poll summary image](https://poll.example/summary/12.png)<br>',
+            rendered,
+        )
+        self.assertNotIn('<img src="https://poll.example/summary/12.png"', rendered)
+
     def test_includes_the_peoples_poll_link(self):
         request = RequestFactory().get('/poll_post/')
         request.user = SimpleNamespace(is_anonymous=False, is_staff=False, username='test-user')
@@ -35,6 +63,7 @@ class PollPostTemplateTests(SimpleTestCase):
                 'faq': 'https://poll.example/faq',
                 'contribute': 'https://poll.example/contribute',
                 'hall': 'https://poll.example/hall',
+                'summary_image': 'https://poll.example/summary/12.png',
             },
         }, request)
 


### PR DESCRIPTION
## What changed

- Replace the inline summary-image preview in the post generator with a Markdown link to the hosted image.
- Keep the generated post focused on copyable Reddit content while preserving the stable public summary URL.
- Add template coverage to verify the link is present and the summary image is not embedded.

## Validation

- `python manage.py test poll.test_poll_post poll.test_post_summary poll`
- 23 tests passing.
