### PR TITLE
Fix flake8 formatting in provisional screening migration

### DIFF
--- a/app/poll/migrations/0004_provisional_application_screening.py
+++ b/app/poll/migrations/0004_provisional_application_screening.py
@@ -2,13 +2,31 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    dependencies = [('poll', '0003_reddit_accounts')]
+    dependencies = [
+        ('poll', '0003_reddit_accounts'),
+    ]
     operations = [
-        migrations.AddField(model_name='provisionaluserapplication', name='decision_source',
-            field=models.CharField(blank=True, choices=[('MANUAL', 'Manual'), ('AUTOMATIC', 'Automatic')],
-                                   max_length=20, null=True)),
-        migrations.AddField(model_name='provisionaluserapplication', name='screening_flags',
-            field=models.JSONField(default=list)),
-        migrations.AddField(model_name='provisionaluserapplication', name='screened_at',
-            field=models.DateTimeField(blank=True, null=True)),
+        migrations.AddField(
+            model_name='provisionaluserapplication',
+            name='decision_source',
+            field=models.CharField(
+                blank=True,
+                choices=[('MANUAL', 'Manual'), ('AUTOMATIC', 'Automatic')],
+                max_length=20,
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name='provisionaluserapplication',
+            name='screening_flags',
+            field=models.JSONField(default=list),
+        ),
+        migrations.AddField(
+            model_name='provisionaluserapplication',
+            name='screened_at',
+            field=models.DateTimeField(
+                blank=True,
+                null=True,
+            ),
+        ),
     ]


### PR DESCRIPTION
### Problem

Production Docker build failed because migration `0004_provisional_application_screening.py` violated E128 under the Dockerfile's repository-wide flake8 command.

### Fix

Formatting-only change; migration semantics unchanged.

### Validation

- `flake8 --ignore=E501,F401,W503 .` — passed in the production Dockerfile builder stage (`flake8==3.9.2`).
- `python manage.py makemigrations --check` — passed: No changes detected.
- `python manage.py check` — passed; two pre-existing django-allauth deprecation warnings.
- `python manage.py test` — passed: 52 tests, OK, against disposable PostgreSQL.
- `pip check` — passed: No broken requirements found.
- `git diff --check` — passed.
- Full production Docker image build — passed locally.

No unrelated repository-wide flake8 errors remain.
